### PR TITLE
urlencode() troublesome url params and consistent camelCase

### DIFF
--- a/src/Api/Groups.php
+++ b/src/Api/Groups.php
@@ -34,12 +34,12 @@ class Groups extends ApiAbstract {
      * Get single subscriber from group
      *
      * @param $groupId
-     * @param $subscriber_id
+     * @param $subscriberId
      * @return mixed
      */
-    public function getSubscriber($groupId, $subscriber_id)
+    public function getSubscriber($groupId, $subscriberId)
     {
-        $endpoint = $this->endpoint . '/' . $groupId . '/subscribers/' . $subscriber_id;
+        $endpoint = $this->endpoint . '/' . $groupId . '/subscribers/' . urlencode($subscriberId);
 
         $response = $this->restClient->get($endpoint);
 
@@ -73,7 +73,7 @@ class Groups extends ApiAbstract {
      */
     public function removeSubscriber($groupId, $subscriberId)
     {
-        $endpoint = $this->endpoint . '/' . $groupId . '/subscribers/' . $subscriberId;
+        $endpoint = $this->endpoint . '/' . $groupId . '/subscribers/' . urlencode($subscriberId);
 
         $response = $this->restClient->delete($endpoint);
 

--- a/src/Api/Subscribers.php
+++ b/src/Api/Subscribers.php
@@ -17,7 +17,7 @@ class Subscribers extends ApiAbstract {
      */
     public function getGroups($subscriberId, $params = [])
     {
-        $endpoint = $this->endpoint . '/' . $subscriberId . '/groups';
+        $endpoint = $this->endpoint . '/' . urlencode($subscriberId) . '/groups';
 
         $params = array_merge($this->prepareParams(), $params);
 
@@ -36,7 +36,7 @@ class Subscribers extends ApiAbstract {
      */
     public function getActivity($subscriberId, $type = null, $params = [])
     {
-        $endpoint = $this->endpoint . '/' . $subscriberId . '/activity';
+        $endpoint = $this->endpoint . '/' . urlencode($subscriberId) . '/activity';
 
         if ($type !== null) {
             $endpoint .= '/' . $type;


### PR DESCRIPTION
I uncovered an issue where certain endpoints wouldn't work correctly when passing in identifiers for subscribers that end up in the URL path.

e.g. emails with a `+` in them would incorrectly return `subscriber not found` in the response.