### PR TITLE
Update composer packages to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     "require": {
         "php" : "^5.5|^7.0",
         "guzzlehttp/psr7": "~1.2",
-        "php-http/httplug": "^1.0",
-        "php-http/curl-client": "^1.4",
+        "php-http/httplug": "^2.0",
+        "php-http/curl-client": "^2.1",
         "php-http/message": "^1.2"
     },
     "require-dev": {
-        "php-http/guzzle6-adapter": "^1.0",
+        "php-http/guzzle6-adapter": "^2.0",
         "phpunit/phpunit": "5.3.*",
         "mockery/mockery": "^0.9.4"
     },


### PR DESCRIPTION
In order for me to use Mailerlite with other vendors, I needed to update the composer packages.

I tested this on my site and everything seems to work as expected.

Issue: https://github.com/mailerlite/mailerlite-api-v2-php-sdk/issues/31