### PR TITLE
Update readme to indicate this library is for MailerLite Classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# MailerLite API v2 PHP SDK
+# MailerLite Classic API v2 PHP SDK
 
-It is an official PHP SDK for MailerLite API v2.
+**This library is for MailerLite Classic. If you want to integrate with MailerLite please use https://github.com/mailerlite/mailerlite-php instead.**
 
-You can find more examples and information about MailerLite API v2 here: [https://developers.mailerlite.com](https://developers.mailerlite.com)
+It is an official PHP SDK for the MailerLite Classic API.
+
+You can find more examples and information about the MailerLite Classic API here: [https://developers-classic.mailerlite.com/docs](https://developers-classic.mailerlite.com/docs)
 
 ## Getting started
 
@@ -92,4 +94,4 @@ You are welcome to create SDK for any other programming language.
 
 If you have any troubles using our API or SDK free to contact our support by email [info@mailerlite.com](mailto:info@mailerlite)
 
-Official documentation is at [https://developers.mailerlite.com](https://developers.mailerlite.com)
+Official documentation is at [https://developers-classic.mailerlite.com/docs](https://developers-classic.mailerlite.com/docs)


### PR DESCRIPTION
Updates the readme to indicate this library is for MailerLite Classic instead of MailerLite.